### PR TITLE
fix: remove hardcoded us-central1 from container image names

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,17 +191,17 @@ We have three steps:
 
 Before we deploy anything, we need to update the Kubernetes YAML files to point
 to the images we built above. Right now if you look in any of the job.yaml or
-deployment.yaml files, you'll see the image has a `__PROJECT__` string in the
-`image` property. We need to change this. Fortunately, we have a script to do
-this for us. For two project setups, the project name should be the project
+deployment.yaml files, you'll see the image has a `__PROJECT__` and `__REGION__`
+string in the `image` property. We need to change this. Fortunately, we have a
+script to do this for us. For two project setups, the project name should be the project
 that hosts the GKE cluster and where the images were built above.
 
 ```sh
-./scripts/configure-k8s.sh <YOUR_PROJECT_HERE>
+./scripts/configure-k8s.sh <YOUR_PROJECT_HERE> <YOUR_CHOSEN_REGION>
 
 # For example:
 
-./scripts/configure-k8s.sh my-cool-project
+./scripts/configure-k8s.sh my-cool-project us-central1
 ```
 
 Now let's connect kubectl to your cluster:

--- a/chatbot-api/k8s/deployment.yaml
+++ b/chatbot-api/k8s/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: "app-sa"
       containers:
       - name: chatbotapi
-        image: us-central1-docker.pkg.dev/__PROJECT__/default-repository/chatbotapi:latest
+        image: __REGION__-docker.pkg.dev/__PROJECT__/default-repository/chatbotapi:latest
         ports:
         - containerPort: 80
         resources:

--- a/init-db/k8s/job.yaml
+++ b/init-db/k8s/job.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: init-db
-        image: us-central1-docker.pkg.dev/__PROJECT__/default-repository/init-db:latest
+        image: __REGION__-docker.pkg.dev/__PROJECT__/default-repository/init-db:latest
         env:
         - name: DB_HOST
           valueFrom:

--- a/load-embeddings/k8s/job.yaml
+++ b/load-embeddings/k8s/job.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: "app-sa"
       containers:
       - name: load-embeddings
-        image: us-central1-docker.pkg.dev/__PROJECT__/default-repository/load-embeddings:latest
+        image: __REGION__-docker.pkg.dev/__PROJECT__/default-repository/load-embeddings:latest
         env:
         - name: DB_HOST
           valueFrom:

--- a/scripts/configure-k8s.sh
+++ b/scripts/configure-k8s.sh
@@ -37,4 +37,7 @@ yaml_templates = [
 ]
 
 for t in yaml_templates:
-    prepare_template(t, sys.argv[1], sys.argv[2])
+    if len(sys.argv) == 3:
+        prepare_template(t, sys.argv[1], sys.argv[2])
+    else:
+        prepare_template(t, sys.argv[1])

--- a/scripts/configure-k8s.sh
+++ b/scripts/configure-k8s.sh
@@ -17,12 +17,14 @@
 import sys
 
 
-def prepare_template(filename, project_name):
+def prepare_template(filename, project_name, region="us-central1"):
     lines = []
     with open(filename, "r") as fin:
         for line in fin:
             if "__PROJECT__" in line:
                 line = line.replace("__PROJECT__", project_name)
+            if "__REGION__" in line:
+                line = line.replace("__REGION__", region)
             lines.append(line)
     with open(filename, "w") as fout:
         fout.writelines(lines)
@@ -35,4 +37,4 @@ yaml_templates = [
 ]
 
 for t in yaml_templates:
-    prepare_template(t, sys.argv[1])
+    prepare_template(t, sys.argv[1], sys.argv[2])


### PR DESCRIPTION
A few of the k8s yaml files have us-central1 hardcoded as the region for the container images. Updating helper script to replace region as well.

For current  users I have defaulted to us-central1 for backwards compatibility if script is not passed a region.